### PR TITLE
Adjust check-all fallback ordering for inventory checks

### DIFF
--- a/resources/js/Pages/Inventory.vue
+++ b/resources/js/Pages/Inventory.vue
@@ -270,16 +270,22 @@ import { reactive } from 'vue'
       })
       const norm = v => v ?? ''
 
-      checkAllList.value = itemsCheckNecessary.value.sort((a, b) => {
-        const la = a.location ?? {}
-        const lb = b.location ?? {}
+      const itemsToCheck = itemsCheckNecessary.value.length > 0
+        ? [ ...itemsCheckNecessary.value ].sort((a, b) => {
+            const la = a.location ?? {}
+            const lb = b.location ?? {}
 
-        return (
-          collator.compare(norm(la.room),  norm(lb.room))  ||
-          collator.compare(norm(la.cab),   norm(lb.cab))   ||
-          collator.compare(norm(la.exact), norm(lb.exact))
-        )
-      }).map(item => item.id)
+            return (
+              collator.compare(norm(la.room),  norm(lb.room))  ||
+              collator.compare(norm(la.cab),   norm(lb.cab))   ||
+              collator.compare(norm(la.exact), norm(lb.exact))
+            )
+          })
+        : [ ...inventoryStore.items ]
+          .filter(item => item.current_quantity < item.max_stock)
+          .sort((a, b) => a.current_quantity - b.current_quantity)
+
+      checkAllList.value = itemsToCheck.map(item => item.id)
 
       clearSelectedItem(true)
     }


### PR DESCRIPTION
### Motivation
- Ensure the `Prüfe Alle` action still iterates items when there are no items flagged as needing a regular check by falling back to low-stock items.
- Provide a sensible ordering for the fallback set so users review the lowest `current_quantity` first.

### Description
- Updated `checkAllNecessaryItems` to compute an `itemsToCheck` list which uses the existing location-based ordering when `itemsCheckNecessary` is non-empty and otherwise falls back to `inventoryStore.items` filtered by `item.current_quantity < item.max_stock`.
- The fallback list is sorted by `current_quantity` ascending and the resulting list is mapped into `checkAllList` as before.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a58c45948832ebc6603443d9e045e)